### PR TITLE
fix: total_cost must be float

### DIFF
--- a/src/DTO/CostResponseData.php
+++ b/src/DTO/CostResponseData.php
@@ -50,9 +50,9 @@ class CostResponseData extends DataTransferObject
     /**
      * Total cost of the request
      *
-     * @var int
+     * @var float
      */
-    public int $total_cost;
+    public float $total_cost;
 
     /**
      * Origin of the request


### PR DESCRIPTION
Openrouter returns total_cost as float value. For example: https://openrouter.ai/api/v1/generation?id=gen-AYGnlU22ZLjmejkTr0xizfqs0nes