### PR TITLE
fix: usage in CostResponseData must be float

### DIFF
--- a/src/DTO/CostResponseData.php
+++ b/src/DTO/CostResponseData.php
@@ -176,7 +176,7 @@ class CostResponseData extends DataTransferObject
     /**
      * Usage associated with the request
      *
-     * @var int|null
+     * @var float|null
      */
-    public ?int $usage;
+    public ?float $usage;
 }


### PR DESCRIPTION
Like total_cost (https://github.com/moe-mizrak/laravel-openrouter/pull/19) usage must be float too.