### PR TITLE
fix: add default value to citations to resolve deprecation warning

### DIFF
--- a/src/DTO/ResponseData.php
+++ b/src/DTO/ResponseData.php
@@ -64,7 +64,7 @@ final class ResponseData extends DataTransferObject
          *
          * @var string[]|null
          */
-        public ?array $citations,
+        public ?array $citations = null,
 
         /**
          * Depending on whether you set "stream" to "true"


### PR DESCRIPTION
### What:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Update the README.md
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Description:

This fixes the issue #59

- To resolve the deprecated warning, I've assigned a default null value to `citations` parameter.
- After the changes, I've tested running locally, and the warning is not showing anymore.

