### PR TITLE
feat: add modalities and image configuration to ChatData DTO

### DIFF
--- a/src/DTO/ChatData.php
+++ b/src/DTO/ChatData.php
@@ -147,6 +147,23 @@ final class ChatData extends DataTransferObject
          * @var bool|null
          */
         public ?bool $include_reasoning = false,
+
+        /**
+         * Modalities for the completion request.
+         * Specify both "image" and "text" to enable image generation.
+         * Example: ["image", "text"]
+         *
+         * @var array|null
+         */
+        public ?array $modalities = null,
+
+        /**
+         * Configuration for image generation.
+         * See: https://openrouter.ai/docs/docs/overview/multimodal/image-generation
+         *
+         * @var ImageConfigData|null
+         */
+        public ?ImageConfigData $image_config = null,
     ) {
         $this->validateXorFields($this->messages, $this->prompt);
         $this->validateXorFields($this->model, $this->models);
@@ -221,6 +238,8 @@ final class ChatData extends DataTransferObject
                 'route'              => $this->route,
                 'provider'           => $this->provider?->convertToArray(),
                 'include_reasoning'  => $this->include_reasoning,
+                'modalities'         => $this->modalities,
+                'image_config'       => $this->image_config?->convertToArray(),
             ],
             fn($value) => $value !== null
         );

--- a/src/DTO/ImageConfigData.php
+++ b/src/DTO/ImageConfigData.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoeMizrak\LaravelOpenrouter\DTO;
+
+use MoeMizrak\LaravelOpenrouter\Rules\AllowedValues;
+
+/**
+ * DTO for image configuration in chat completion requests.
+ *
+ * Class ImageConfigData
+ * @package MoeMizrak\LaravelOpenrouter\DTO
+ */
+final class ImageConfigData extends DataTransferObject
+{
+    /**
+     * @inheritDoc
+     */
+    public function __construct(
+        /**
+         * The aspect ratio for generated images.
+         * Supported values: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9
+         * Default: 1:1 (1024×1024)
+         *
+         * @var string|null
+         */
+        #[AllowedValues(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'])]
+        public ?string $aspect_ratio = null,
+    ) {
+        parent::__construct(...func_get_args());
+    }
+
+    /**
+     * @return array
+     */
+    public function convertToArray(): array
+    {
+        return array_filter(
+            [
+                'aspect_ratio' => $this->aspect_ratio,
+            ],
+            fn($value) => $value !== null
+        );
+    }
+}


### PR DESCRIPTION
## Add support for image generation configuration

### Description
This PR adds support for image generation configuration options as documented in the [OpenRouter Multimodal Image Generation docs](https://openrouter.ai/docs/docs/overview/multimodal/image-generation).

### Motivation
While using the library to generate images with OpenRouter models (e.g., Nano Banana), I noticed that the `image_config` and `modalities` parameters from the official documentation weren't available in the package. Although image generation works without explicitly setting `modalities`, adding these parameters allows for better control over the output format and aspect ratio.

### Changes
- ✨ **New DTO**: Added `ImageConfigData` class to handle image configuration options
  - Supports `aspect_ratio` parameter with validation for all documented values (1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9)
- 🔧 **Updated `ChatData`**: Added two new optional properties:
  - `modalities`: Array to specify output modalities (e.g., `["image", "text"]`)
  - `image_config`: Instance of `ImageConfigData` for image generation settings
- ✅ Both properties are properly serialized in the API request

### Usage Example
```php
use MoeMizrak\LaravelOpenrouter\DTO\ChatData;
use MoeMizrak\LaravelOpenrouter\DTO\MessageData;
use MoeMizrak\LaravelOpenrouter\DTO\ImageConfigData;

$chatData = new ChatData(
    messages: [
        new MessageData(
            role: 'user',
            content: 'Generate a beautiful sunset over mountains'
        )
    ],
    model: 'google/gemini-2.5-flash-image-preview',
    modalities: ['image', 'text'],
    image_config: new ImageConfigData(
        aspect_ratio: '16:9'
    )
);

$response = app(OpenRouterRequest::class)->chatRequest($chatData);
```