### PR TITLE
feat: add new cache_control field

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This Laravel package provides an easy-to-use interface for integrating **[OpenRo
       - [Web Search](#web-search)
       - [File/Document Inputs](#filedocument-inputs)
       - [Audio Inputs](#audio-inputs)
+      - [Prompt caching](#prompt-caching)
     - [Cost Request](#cost-request)
     - [Limit Request](#limit-request)
   - [Using OpenRouterRequest Class](#using-openrouterrequest-class)
@@ -117,6 +118,7 @@ The [`ChatData`](src/DTO/ChatData.php) class is used to **encapsulate the data**
 - **stream** (bool|null): A boolean indicating whether streaming should be enabled or not.
 - **include_reasoning** (bool|null): Whether to return the model's reasoning (Note: this parameter is **deprecated**, use `reasoning` parameter instead. For backward compatibility, package still supports the `include_reasoning` parameter)
 - **reasoning** (ReasoningData|null): An instance of the [`ReasoningData`](src/DTO/ReasoningData.php) class for reasoning configuration. It provides a transparent look into the reasoning steps taken by a model.
+- **cache_control** (`[CacheControlData](src/DTO/CacheControlData.php)`|null): Controls **prompt caching** on supported providers/models. You can set it at the **top-level** of the request (recommended for multi-turn conversations) or as an explicit **breakpoint** on large text blocks via `TextContentData::$cache_control`. For details and provider-specific behavior, see `[OpenRouter Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)`.
 
 #### LLM Parameters
 
@@ -971,6 +973,69 @@ $response = LaravelOpenRouter::chatRequest($chatData);
 > Only `mp3` and `wav` formats are supported for audio inputs.
 > 
 > And make sure to provide valid `base64-encoded` audio data.
+
+- #### Prompt caching
+
+OpenRouter supports prompt caching on supported providers/models to decrease cost and latency on repeated requests. This package supports both approaches described in OpenRouter docs:
+
+- **Top-level caching** (recommended for multi-turn conversations): set `ChatData::$cache_control`.
+- **Explicit cache breakpoint** (fine-grained control): set `TextContentData::$cache_control` on the *large* text block(s) you want to cache (e.g. RAG data, CSV data, long instructions, etc).
+
+OpenRouter docs: [Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)
+
+**Top-level example (automatic caching):**
+
+```php
+use MoeMizrak\LaravelOpenrouter\DTO\CacheControlData;
+use MoeMizrak\LaravelOpenrouter\DTO\ChatData;
+use MoeMizrak\LaravelOpenrouter\DTO\MessageData;
+use MoeMizrak\LaravelOpenrouter\Types\RoleType;
+
+$chatData = new ChatData(
+    messages: [
+        new MessageData(
+            role: RoleType::USER,
+            content: 'What triggered the collapse?',
+        ),
+    ],
+    model: 'anthropic/claude-sonnet-4.6',
+    cache_control: new CacheControlData(
+        type: CacheControlData::ALLOWED_TYPE, // "ephemeral"
+        ttl: '1h', // optional
+    ),
+);
+```
+
+**Explicit breakpoint example (cache a large text block):**
+
+```php
+use MoeMizrak\LaravelOpenrouter\DTO\CacheControlData;
+use MoeMizrak\LaravelOpenrouter\DTO\ChatData;
+use MoeMizrak\LaravelOpenrouter\DTO\MessageData;
+use MoeMizrak\LaravelOpenrouter\DTO\TextContentData;
+use MoeMizrak\LaravelOpenrouter\Types\RoleType;
+
+$chatData = new ChatData(
+    messages: [
+        new MessageData(
+            role: RoleType::USER,
+            content: [
+                new TextContentData(
+                    text: 'Given the book below:',
+                ),
+                new TextContentData(
+                    text: 'HUGE TEXT BODY',
+                    cache_control: new CacheControlData(), // {"type":"ephemeral"}
+                ),
+                new TextContentData(
+                    text: 'What triggered the collapse?',
+                ),
+            ],
+        ),
+    ],
+    model: 'anthropic/claude-sonnet-4.6',
+);
+```
 
 #### Cost Request
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The [`ChatData`](src/DTO/ChatData.php) class is used to **encapsulate the data**
 - **stream** (bool|null): A boolean indicating whether streaming should be enabled or not.
 - **include_reasoning** (bool|null): Whether to return the model's reasoning (Note: this parameter is **deprecated**, use `reasoning` parameter instead. For backward compatibility, package still supports the `include_reasoning` parameter)
 - **reasoning** (ReasoningData|null): An instance of the [`ReasoningData`](src/DTO/ReasoningData.php) class for reasoning configuration. It provides a transparent look into the reasoning steps taken by a model.
-- **cache_control** ([`CacheControlData`](src/DTO/CacheControlData.php)|null): Controls **prompt caching** on supported providers/models. You can set it at the **top-level** of the request (recommended for multi-turn conversations) or as an explicit **breakpoint** on large text blocks via `TextContentData::$cache_control`. For details and provider-specific behavior, see `[OpenRouter Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)`.
+- **cache_control** ([`CacheControlData`](src/DTO/CacheControlData.php)|null): Controls **prompt caching** on supported providers/models. You can set it at the **top-level** of the request (recommended for multi-turn conversations) or as an explicit **breakpoint** on large text blocks via `TextContentData::$cache_control`. For details and provider-specific behavior, see [OpenRouter Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching).
 
 #### LLM Parameters
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The [`ChatData`](src/DTO/ChatData.php) class is used to **encapsulate the data**
 - **stream** (bool|null): A boolean indicating whether streaming should be enabled or not.
 - **include_reasoning** (bool|null): Whether to return the model's reasoning (Note: this parameter is **deprecated**, use `reasoning` parameter instead. For backward compatibility, package still supports the `include_reasoning` parameter)
 - **reasoning** (ReasoningData|null): An instance of the [`ReasoningData`](src/DTO/ReasoningData.php) class for reasoning configuration. It provides a transparent look into the reasoning steps taken by a model.
-- **cache_control** (`[CacheControlData](src/DTO/CacheControlData.php)`|null): Controls **prompt caching** on supported providers/models. You can set it at the **top-level** of the request (recommended for multi-turn conversations) or as an explicit **breakpoint** on large text blocks via `TextContentData::$cache_control`. For details and provider-specific behavior, see `[OpenRouter Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)`.
+- **cache_control** ([`CacheControlData`](src/DTO/CacheControlData.php)|null): Controls **prompt caching** on supported providers/models. You can set it at the **top-level** of the request (recommended for multi-turn conversations) or as an explicit **breakpoint** on large text blocks via `TextContentData::$cache_control`. For details and provider-specific behavior, see `[OpenRouter Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)`.
 
 #### LLM Parameters
 
@@ -979,7 +979,7 @@ $response = LaravelOpenRouter::chatRequest($chatData);
 OpenRouter supports prompt caching on supported providers/models to decrease cost and latency on repeated requests. This package supports both approaches described in OpenRouter docs:
 
 - **Top-level caching** (recommended for multi-turn conversations): set `ChatData::$cache_control`.
-- **Explicit cache breakpoint** (fine-grained control): set `TextContentData::$cache_control` on the *large* text block(s) you want to cache (e.g. RAG data, CSV data, long instructions, etc).
+- **Explicit cache breakpoint** (fine-grained control): set `TextContentData::$cache_control` on the *large* text block(s) you want to cache (e.g. RAG data, CSV data, long instructions, etc.).
 
 OpenRouter docs: [Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)
 

--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,10 @@ $chatData = new ChatData(
                 ),
                 new TextContentData(
                     text: 'HUGE TEXT BODY',
-                    cache_control: new CacheControlData(), // {"type":"ephemeral"}
+                    cache_control: new CacheControlData(
+                        type: CacheControlData::ALLOWED_TYPE, // "ephemeral"
+                        ttl: '1h', // optional
+                    ),
                 ),
                 new TextContentData(
                     text: 'What triggered the collapse?',

--- a/src/DTO/CacheControlData.php
+++ b/src/DTO/CacheControlData.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoeMizrak\LaravelOpenrouter\DTO;
+
+use MoeMizrak\LaravelOpenrouter\Rules\AllowedValues;
+
+/**
+ * DTO for the prompt caching control.
+ *
+ * Docs: https://openrouter.ai/docs/guides/best-practices/prompt-caching
+ *
+ * Class CacheControlData
+ * @package MoeMizrak\LaravelOpenrouter\DTO
+ */
+final class CacheControlData extends DataTransferObject
+{
+    /**
+     * The allowed cache_control type value.
+     */
+    public const ALLOWED_TYPE = 'ephemeral';
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(
+        /**
+         * Cache control type. Currently OpenRouter documents "ephemeral".
+         *
+         * @var string
+         */
+        #[AllowedValues([self::ALLOWED_TYPE])]
+        public string $type = self::ALLOWED_TYPE,
+
+        /**
+         * Optional TTL for cache entry.
+         * Example: "1h"
+         *
+         * @var string|null
+         */
+        public ?string $ttl = null,
+    ) {
+        parent::__construct(...func_get_args());
+    }
+
+    /**
+     * @return array
+     */
+    public function convertToArray(): array
+    {
+        return array_filter(
+            [
+                'type' => $this->type,
+                'ttl'  => $this->ttl,
+            ],
+            fn($value) => $value !== null
+        );
+    }
+}

--- a/src/DTO/ChatData.php
+++ b/src/DTO/ChatData.php
@@ -189,6 +189,16 @@ final class ChatData extends DataTransferObject
          * @var ImageConfigData|null
          */
         public ?ImageConfigData $image_config = null,
+
+        /**
+         * Prompt caching control.
+         * Can be passed at the top-level of the request (recommended for multi-turn conversations)
+         * or as a breakpoint inside individual content blocks (see TextContentData).
+         * See: https://openrouter.ai/docs/guides/best-practices/prompt-caching
+         *
+         * @var CacheControlData|null
+         */
+        public ?CacheControlData $cache_control = null,
     ) {
         $this->validateXorFields($this->messages, $this->prompt);
         $this->validateXorFields($this->model, $this->models);
@@ -280,6 +290,7 @@ final class ChatData extends DataTransferObject
                 'modalities'         => $this->modalities,
                 'image_config'       => $this->image_config?->convertToArray(),
                 'reasoning'          => $this->reasoning?->convertToArray(),
+                'cache_control'      => $this->cache_control?->convertToArray(),
             ],
             fn($value) => $value !== null
         );

--- a/src/DTO/TextContentData.php
+++ b/src/DTO/TextContentData.php
@@ -37,6 +37,16 @@ final class TextContentData extends DataTransferObject
          * @var string
          */
         public string $text,
+
+        /**
+         * Optional cache breakpoint for this content block.
+         * Useful for explicit caching (e.g. caching a large reference text).
+         *
+         * Docs: https://openrouter.ai/docs/guides/best-practices/prompt-caching
+         *
+         * @var CacheControlData|null
+         */
+        public ?CacheControlData $cache_control = null,
     ) {
         parent::__construct(...func_get_args());
     }
@@ -50,6 +60,7 @@ final class TextContentData extends DataTransferObject
             [
                 'type' => $this->type,
                 'text' => $this->text,
+                'cache_control' => $this->cache_control?->convertToArray(),
             ],
             fn($value) => $value !== null
         );

--- a/tests/OpenRouterAPITest.php
+++ b/tests/OpenRouterAPITest.php
@@ -1730,8 +1730,6 @@ class OpenRouterAPITest extends TestCase
         );
 
         $payload = $chatData->convertToArray();
-        $this->assertArrayHasKey('cache_control', $payload);
-        $this->assertEquals(['type' => 'ephemeral', 'ttl' => '1h'], $payload['cache_control']);
 
         $this->mockOpenRouter($this->mockBasicBody());
 
@@ -1739,6 +1737,8 @@ class OpenRouterAPITest extends TestCase
         $response = $this->api->chatRequest($chatData);
 
         /* ASSERT */
+        $this->assertArrayHasKey('cache_control', $payload);
+        $this->assertEquals(['type' => 'ephemeral', 'ttl' => '1h'], $payload['cache_control']);
         $this->generalTestAssertions($response);
     }
 }

--- a/tests/OpenRouterAPITest.php
+++ b/tests/OpenRouterAPITest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Arr;
 use Mockery\MockInterface;
 use MoeMizrak\LaravelOpenrouter\DTO\AudioContentData;
+use MoeMizrak\LaravelOpenrouter\DTO\CacheControlData;
 use MoeMizrak\LaravelOpenrouter\DTO\ChatData;
 use MoeMizrak\LaravelOpenrouter\DTO\CompletionTokensDetailsData;
 use MoeMizrak\LaravelOpenrouter\DTO\CostResponseData;
@@ -1710,5 +1711,34 @@ class OpenRouterAPITest extends TestCase
         $this->assertArrayNotHasKey('preferred_min_throughput', $array);
         $this->assertArrayNotHasKey('preferred_max_latency', $array);
         $this->assertArrayNotHasKey('max_price', $array);
+    }
+
+    #[Test]
+    public function it_sends_cache_control_in_request_body()
+    {
+        /* SETUP */
+        $chatData = new ChatData(
+            messages: [
+                $this->messageData,
+            ],
+            model: $this->model,
+            max_tokens: $this->maxTokens,
+            cache_control: new CacheControlData(
+                type: CacheControlData::ALLOWED_TYPE,
+                ttl: '1h',
+            )
+        );
+
+        $payload = $chatData->convertToArray();
+        $this->assertArrayHasKey('cache_control', $payload);
+        $this->assertEquals(['type' => 'ephemeral', 'ttl' => '1h'], $payload['cache_control']);
+
+        $this->mockOpenRouter($this->mockBasicBody());
+
+        /* EXECUTE */
+        $response = $this->api->chatRequest($chatData);
+
+        /* ASSERT */
+        $this->generalTestAssertions($response);
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Update the README.md
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Description:

Adds support for OpenRouter **prompt caching** via `cache_control` parameter

References:
```https://openrouter.ai/docs/guides/best-practices/prompt-caching```

**Changes:**

- Added new DTO [`CacheControlData`](src/DTO/CacheControlData.php) with `type` (currently `ephemeral`) and optional `ttl` (e.g. `1h`).
- Added to [`ChatData`](src/DTO/ChatData.php): optional top-level `cache_control`.
- Added to [`TextContentData`](src/DTO/TextContentData.php): optional `cache_control` for explicit cache breakpoints on large text segments.
- Added PHPUnit test for this feature.
- Updated [`README.md`](README.md) field documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prompt caching for chat requests, configurable at the request level or per text segment.
  * Introduced cache control options (including ephemeral type) with optional TTL for expiry.

* **Documentation**
  * Added "Prompt caching" section and updated Table of Contents with usage examples.

* **Tests**
  * Added tests confirming cache control is included in chat request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->