### PR TITLE
feat: Add session_id and debug options to ChatData DTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The [`ChatData`](src/DTO/ChatData.php) class is used to **encapsulate the data**
 - **include_reasoning** (bool|null): Whether to return the model's reasoning (Note: this parameter is **deprecated**, use `reasoning` parameter instead. For backward compatibility, package still supports the `include_reasoning` parameter)
 - **reasoning** (ReasoningData|null): An instance of the [`ReasoningData`](src/DTO/ReasoningData.php) class for reasoning configuration. It provides a transparent look into the reasoning steps taken by a model.
 - **cache_control** ([`CacheControlData`](src/DTO/CacheControlData.php)|null): Controls **prompt caching** on supported providers/models. You can set it at the **top-level** of the request (recommended for multi-turn conversations) or as an explicit **breakpoint** on large text blocks via `TextContentData::$cache_control`. For details and provider-specific behavior, see [OpenRouter Prompt Caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching).
+- **session_id** (string|null): A string representing the session ID for maintaining conversation continuity across multiple requests. When provided, OpenRouter will attempt to route the request to the same provider and model used in previous interactions with the same session ID, helping to maintain context and coherence in multi-turn conversations. For more details, see [OpenRouter Broadcast](https://openrouter.ai/docs/guides/features/broadcast/overview).
+- **debug** (DebugData|null): An instance of the [`DebugData`](src/DTO/DebugData.php) class for debugging options (e.g., `echo_upstream_body` to include raw upstream responses in the output for troubleshooting).
 
 #### LLM Parameters
 

--- a/src/DTO/ChatData.php
+++ b/src/DTO/ChatData.php
@@ -16,8 +16,7 @@ use MoeMizrak\LaravelOpenrouter\Types\ToolChoiceType;
  * Class ChatData
  * @package MoeMizrak\LaravelOpenrouter\DTO
  */
-final class ChatData extends DataTransferObject
-{
+final class ChatData extends DataTransferObject {
     /**
      * @inheritDoc
      */
@@ -199,6 +198,27 @@ final class ChatData extends DataTransferObject
          * @var CacheControlData|null
          */
         public ?CacheControlData $cache_control = null,
+
+        /**
+         * Debug.
+         * This parameter is for debugging purposes and will not be sent to the model. It can be used to pass any additional information that you want to include in the request for debugging purposes.
+         * Debug options for inspecting request transformations (streaming only)
+         * See: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#request.body.debug
+         * 
+         * @var DebugData|null
+         */
+
+        public ?DebugData $debug = null,
+
+        /**
+         * Session ID.
+         * A unique identifier for grouping related requests (e.g., a conversation or agent workflow) for observability. If provided in both the request body and the x-session-id header, the body value takes precedence. Maximum of 256 characters.
+         * See: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#request.body.session_id
+         * 
+         * @var string|null
+         */
+
+        public ?string $session_id = null,
     ) {
         $this->validateXorFields($this->messages, $this->prompt);
         $this->validateXorFields($this->model, $this->models);
@@ -220,8 +240,7 @@ final class ChatData extends DataTransferObject
      * @return void
      * @throws OpenRouterValidationException
      */
-    private function validateXorFields(mixed $firstField, mixed $secondField): void
-    {
+    private function validateXorFields(mixed $firstField, mixed $secondField): void {
         // Validate XOR fields
         $xorFields = new XORFields($firstField, $secondField);
         $validationResult = $xorFields->validate();
@@ -235,8 +254,7 @@ final class ChatData extends DataTransferObject
     /**
      * @return array
      */
-    public function convertToArray(): array
-    {
+    public function convertToArray(): array {
         return array_filter(
             [
                 'messages'           => ! is_null($this->messages)
@@ -291,6 +309,8 @@ final class ChatData extends DataTransferObject
                 'image_config'       => $this->image_config?->convertToArray(),
                 'reasoning'          => $this->reasoning?->convertToArray(),
                 'cache_control'      => $this->cache_control?->convertToArray(),
+                'debug'              => $this->debug?->convertToArray(),
+                'session_id'         => $this->session_id,
             ],
             fn($value) => $value !== null
         );

--- a/src/DTO/DebugData.php
+++ b/src/DTO/DebugData.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoeMizrak\LaravelOpenrouter\DTO;
+
+use MoeMizrak\LaravelOpenrouter\Rules\AllowedValues;
+
+/**
+ * DTO for the debug options.
+ *
+ * Docs: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request#request.body.debug
+ *
+ * Class DebugData
+ * @package MoeMizrak\LaravelOpenrouter\DTO
+ */
+final class DebugData extends DataTransferObject {
+  /**
+   * The allowed debug type value.
+   */
+  public const ALLOWED_TYPE = [false, true];
+
+  /**
+   * @inheritDoc
+   */
+  public function __construct(
+    /**
+     * Debug options for inspecting request transformations (streaming only)
+     * If true, includes the transformed upstream request body in a debug chunk at the start of the stream. Only works with streaming mode.
+     *
+     * @var bool
+     */
+    #[AllowedValues(self::ALLOWED_TYPE)]
+    public bool $echo_upstream_body = false,
+  ) {
+    parent::__construct(...func_get_args());
+  }
+
+  /**
+   * @return array
+   */
+  public function convertToArray(): array {
+    return array_filter(
+      [
+        'echo_upstream_body' => $this->echo_upstream_body,
+      ],
+      fn($value) => $value !== null
+    );
+  }
+}

--- a/src/DTO/DebugData.php
+++ b/src/DTO/DebugData.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MoeMizrak\LaravelOpenrouter\DTO;
 
-use MoeMizrak\LaravelOpenrouter\Rules\AllowedValues;
-
 /**
  * DTO for the debug options.
  *
@@ -16,11 +14,6 @@ use MoeMizrak\LaravelOpenrouter\Rules\AllowedValues;
  */
 final class DebugData extends DataTransferObject {
   /**
-   * The allowed debug type value.
-   */
-  public const ALLOWED_TYPE = [false, true];
-
-  /**
    * @inheritDoc
    */
   public function __construct(
@@ -30,7 +23,6 @@ final class DebugData extends DataTransferObject {
      *
      * @var bool
      */
-    #[AllowedValues(self::ALLOWED_TYPE)]
     public bool $echo_upstream_body = false,
   ) {
     parent::__construct(...func_get_args());

--- a/tests/OpenRouterAPITest.php
+++ b/tests/OpenRouterAPITest.php
@@ -11,6 +11,7 @@ use MoeMizrak\LaravelOpenrouter\DTO\CacheControlData;
 use MoeMizrak\LaravelOpenrouter\DTO\ChatData;
 use MoeMizrak\LaravelOpenrouter\DTO\CompletionTokensDetailsData;
 use MoeMizrak\LaravelOpenrouter\DTO\CostResponseData;
+use MoeMizrak\LaravelOpenrouter\DTO\DebugData;
 use MoeMizrak\LaravelOpenrouter\DTO\ErrorData;
 use MoeMizrak\LaravelOpenrouter\DTO\FileContentData;
 use MoeMizrak\LaravelOpenrouter\DTO\FileUrlData;
@@ -1739,6 +1740,60 @@ class OpenRouterAPITest extends TestCase
         /* ASSERT */
         $this->assertArrayHasKey('cache_control', $payload);
         $this->assertEquals(['type' => 'ephemeral', 'ttl' => '1h'], $payload['cache_control']);
+        $this->generalTestAssertions($response);
+    }
+
+    #[Test]
+    public function it_sends_session_id_in_request_body()
+    {
+        /* SETUP */
+        $chatData = new ChatData(
+            messages: [
+                $this->messageData,
+            ],
+            model: $this->model,
+            max_tokens: $this->maxTokens,
+            session_id: 'test-session-id'
+        );
+
+        $payload = $chatData->convertToArray();
+
+        $this->mockOpenRouter($this->mockBasicBody());
+
+        /* EXECUTE */
+        $response = $this->api->chatRequest($chatData);
+
+        /* ASSERT */
+        $this->assertArrayHasKey('session_id', $payload);
+        $this->assertEquals('test-session-id', $payload['session_id']);
+        $this->generalTestAssertions($response);
+    }
+
+    #[Test]
+    public function it_sends_debug_id_in_request_body()
+    {
+        /* SETUP */
+        $chatData = new ChatData(
+            messages: [
+                $this->messageData,
+            ],
+            model: $this->model,
+            max_tokens: $this->maxTokens,
+            debug: new DebugData(
+                echo_upstream_body: true
+            )
+        );
+
+        $payload = $chatData->convertToArray();
+
+        $this->mockOpenRouter($this->mockBasicBody());
+
+        /* EXECUTE */
+        $response = $this->api->chatRequest($chatData);
+
+        /* ASSERT */
+        $this->assertArrayHasKey('debug', $payload);
+        $this->assertEquals(['echo_upstream_body' => true], $payload['debug']);
         $this->generalTestAssertions($response);
     }
 }

--- a/tests/OpenRouterAPITest.php
+++ b/tests/OpenRouterAPITest.php
@@ -1770,7 +1770,7 @@ class OpenRouterAPITest extends TestCase
     }
 
     #[Test]
-    public function it_sends_debug_id_in_request_body()
+    public function it_serializes_debug_options_in_chat_data_payload()
     {
         /* SETUP */
         $chatData = new ChatData(
@@ -1786,14 +1786,8 @@ class OpenRouterAPITest extends TestCase
 
         $payload = $chatData->convertToArray();
 
-        $this->mockOpenRouter($this->mockBasicBody());
-
-        /* EXECUTE */
-        $response = $this->api->chatRequest($chatData);
-
         /* ASSERT */
         $this->assertArrayHasKey('debug', $payload);
         $this->assertEquals(['echo_upstream_body' => true], $payload['debug']);
-        $this->generalTestAssertions($response);
     }
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the team to understand the PR and also work on it.
-->

### What:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Update the README.md
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Description:
- Introduced session_id for grouping related requests. It helps us while we have multiple models to trace in 1 or multiple sessions.
- Added DebugData DTO for debugging options.
- Enhanced OpenRouterAPITest with tests for session_id and debug functionality.

### Input & Output Logging (New)
<img width="636" height="61" alt="Screenshot 2026-04-23 at 22 00 20" src="https://github.com/user-attachments/assets/2628fb16-efa8-455e-8a62-2f99b7fa0983" />

It's a new feature from OpenRouter, [See here](https://openrouter.ai/workspaces/default/observability)

### Log Session (New)
The session can be logged and traced in OpenRouter dashboard, [See here](https://openrouter.ai/logs?tab=sessions)

### Unit Test Check
<img width="609" height="183" alt="Screenshot 2026-04-23 at 22 07 28" src="https://github.com/user-attachments/assets/c6ba1b19-14b5-4afd-93b5-3cb8aff610ce" />

<!-- describe what your PR is solving -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added optional debug mode for chat requests to monitor upstream request behavior
* Added optional session ID support for improved chat session tracking and correlation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->